### PR TITLE
fix: ensure color-scheme switches properly when system color-scheme is dark

### DIFF
--- a/docs/4/1-2.html
+++ b/docs/4/1-2.html
@@ -17,6 +17,9 @@
             background-color: Background;
             color: MenuText;
         }
+        body {
+            color-scheme: light;
+        }
         body:has(.operate :checked) {
             color-scheme: dark;
         }

--- a/src/views/4/1-2.html
+++ b/src/views/4/1-2.html
@@ -11,6 +11,9 @@
             background-color: Background;
             color: MenuText;
         }
+        body {
+            color-scheme: light;
+        }
         body:has(.operate :checked) {
             color-scheme: dark;
         }


### PR DESCRIPTION
Fixed an issue where the color-scheme could not switch to dark mode when the system color-scheme was set to dark.
Set the body to have a default color-scheme of light to allow proper switching.